### PR TITLE
Fetch api instace

### DIFF
--- a/src/shared/api/api.instance.ts
+++ b/src/shared/api/api.instance.ts
@@ -1,0 +1,330 @@
+import type { ToFormDataOptions } from "../lib/to-form-data";
+import { toFormData } from "../lib/to-form-data";
+import { toQueryParams } from "../lib/to-query-params";
+import { appFetch } from "./app-fetch";
+
+type GetOptions = {
+  params?: Record<string | number, any>;
+} & Partial<Parameters<typeof fetch>[1]>;
+
+type DeleteOptions = {
+  params?: Record<string | number, any>;
+} & Partial<Parameters<typeof fetch>[1]>;
+
+type PostOptions = {
+  params?: Record<string | number, any>;
+} & Partial<Parameters<typeof fetch>[1]>;
+
+type PostFormOptions = {
+  params?: Record<string | number, any>;
+  transformOptions?: ToFormDataOptions;
+} & Partial<Parameters<typeof fetch>[1]>;
+
+type PatchOptions = {
+  params?: Record<string | number, any>;
+} & Partial<Parameters<typeof fetch>[1]>;
+
+type PatchFormOptions = {
+  params?: Record<string | number, any>;
+  transformOptions?: ToFormDataOptions;
+} & Partial<Parameters<typeof fetch>[1]>;
+
+type PutOptions = {
+  params?: Record<string | number, any>;
+} & Partial<Parameters<typeof fetch>[1]>;
+
+type PutFormOptions = {
+  params?: Record<string | number, any>;
+  transformOptions?: ToFormDataOptions;
+} & Partial<Parameters<typeof fetch>[1]>;
+
+type ApiReturn<Req, T = unknown> = {
+  data: T;
+  response: Response;
+  request: Req;
+};
+
+type GetReturn<T = unknown> = ApiReturn<
+  {
+    path: string;
+    options: GetOptions;
+  },
+  T
+>;
+
+type DeleteReturn<T = unknown> = ApiReturn<
+  {
+    path: string;
+    options: GetOptions;
+  },
+  T
+>;
+
+type PostReturn<T = unknown> = ApiReturn<
+  {
+    path: string;
+    options: PostOptions;
+  },
+  T
+>;
+
+type PostFormReturn<T = unknown> = ApiReturn<
+  {
+    path: string;
+    options: PostOptions;
+  },
+  T
+>;
+
+type PatchReturn<T = unknown> = ApiReturn<
+  {
+    path: string;
+    options: PatchOptions;
+  },
+  T
+>;
+
+type PatchFormReturn<T = unknown> = ApiReturn<
+  {
+    path: string;
+    options: PatchFormOptions;
+  },
+  T
+>;
+
+type PutReturn<T = unknown> = ApiReturn<
+  {
+    path: string;
+    options: PutOptions;
+  },
+  T
+>;
+
+type PutFormReturn<T = unknown> = ApiReturn<
+  {
+    path: string;
+    options: PutFormOptions;
+  },
+  T
+>;
+
+class Api {
+  constructor(private fetchFn: typeof fetch) {}
+
+  get = async <T>(path: string, options: GetOptions = {}): Promise<GetReturn<T>> => {
+    const { params, ...restFetchOptions } = options;
+    const url = toQueryParams(path, options.params);
+
+    const response = await this.fetchFn(url, restFetchOptions);
+
+    const request = {
+      path,
+      options,
+    };
+
+    const data = await this.processResponse<T>(response);
+
+    return { data, response, request };
+  };
+
+  delete = async <T>(
+    path: string,
+    options: DeleteOptions = {}
+  ): Promise<DeleteReturn<T>> => {
+    const { params, ...restFetchOptions } = options;
+    const url = toQueryParams(path, options?.params);
+
+    const response = await this.fetchFn(url, {
+      method: "POST",
+      ...restFetchOptions,
+      headers: {
+        ...restFetchOptions.headers,
+      },
+    });
+
+    const request = {
+      path,
+      options,
+    };
+
+    const data = await this.processResponse<T>(response);
+
+    return { data, response, request };
+  };
+
+  post = async <T>(
+    path: string,
+    body?: Record<string | number, any>,
+    options: PostOptions = {}
+  ): Promise<PostReturn<T>> => {
+    const { params, ...restFetchOptions } = options;
+    const url = toQueryParams(path, options?.params);
+
+    const response = await this.fetchFn(url, {
+      method: "POST",
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      ...restFetchOptions,
+      headers: {
+        ...(body ? { "Content-Type": "application/json" } : {}),
+        ...restFetchOptions.headers,
+      },
+    });
+
+    const request = {
+      path,
+      options,
+    };
+
+    const data = await this.processResponse<T>(response);
+
+    return { data, response, request };
+  };
+
+  postForm = async <T>(
+    path: string,
+    body?: Record<string | number, any>,
+    options: PostFormOptions = {}
+  ): Promise<PostFormReturn<T>> => {
+    const { params, ...restFetchOptions } = options;
+    const url = toQueryParams(path, options?.params);
+
+    const response = await this.fetchFn(url, {
+      method: "POST",
+      ...(body ? { body: toFormData(body, options.transformOptions) } : {}),
+      ...restFetchOptions,
+    });
+
+    const request = {
+      path,
+      options,
+    };
+
+    const data = await this.processResponse<T>(response);
+
+    return { data, response, request };
+  };
+
+  patch = async <T>(
+    path: string,
+    body?: Record<string | number, any>,
+    options: PatchOptions = {}
+  ): Promise<PatchReturn<T>> => {
+    const { params, ...restFetchOptions } = options;
+    const url = toQueryParams(path, options?.params);
+
+    const response = await this.fetchFn(url, {
+      method: "PATCH",
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      ...restFetchOptions,
+      headers: {
+        ...(body ? { "Content-Type": "application/json" } : {}),
+        ...restFetchOptions.headers,
+      },
+    });
+
+    const request = {
+      path,
+      options,
+    };
+
+    const data = await this.processResponse<T>(response);
+
+    return { data, response, request };
+  };
+
+  patchForm = async <T>(
+    path: string,
+    body?: Record<string | number, any>,
+    options: PatchFormOptions = {}
+  ): Promise<PatchFormReturn<T>> => {
+    const { params, ...restFetchOptions } = options;
+    const url = toQueryParams(path, options?.params);
+
+    const response = await this.fetchFn(url, {
+      method: "PATCH",
+      ...(body ? { body: toFormData(body, options.transformOptions) } : {}),
+      ...restFetchOptions,
+    });
+
+    const request = {
+      path,
+      options,
+    };
+
+    const data = await this.processResponse<T>(response);
+
+    return { data, response, request };
+  };
+
+  put = async <T>(
+    path: string,
+    body?: Record<string | number, any>,
+    options: PutOptions = {}
+  ): Promise<PutReturn<T>> => {
+    const { params, ...restFetchOptions } = options;
+    const url = toQueryParams(path, options?.params);
+
+    const response = await this.fetchFn(url, {
+      method: "PUT",
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      ...restFetchOptions,
+      headers: {
+        ...(body ? { "Content-Type": "application/json" } : {}),
+        ...restFetchOptions.headers,
+      },
+    });
+
+    const request = {
+      path,
+      options,
+    };
+
+    const data = await this.processResponse<T>(response);
+
+    return { data, response, request };
+  };
+
+  putForm = async <T>(
+    path: string,
+    body?: Record<string | number, any>,
+    options: PutFormOptions = {}
+  ): Promise<PutFormReturn<T>> => {
+    const { params, ...restFetchOptions } = options;
+    const url = toQueryParams(path, options?.params);
+
+    const response = await this.fetchFn(url, {
+      method: "PUT",
+      ...(body ? { body: toFormData(body, options.transformOptions) } : {}),
+      ...restFetchOptions,
+    });
+
+    const request = {
+      path,
+      options,
+    };
+
+    const data = await this.processResponse<T>(response);
+
+    return { data, response, request };
+  };
+
+  private async processResponse<T>(response: Response): Promise<T> {
+    if (response.status >= 400) throw await response.json();
+
+    if (response.status === 204) return null as unknown as T;
+
+    const contentType = response.headers.get("content-type");
+
+    if (contentType?.includes("application/json")) {
+      return (await response.json()) as T;
+    }
+
+    if (contentType?.includes("text/plain")) {
+      return (await response.text()) as unknown as T;
+    }
+
+    return null as unknown as T;
+  }
+}
+
+export const api = new Api(appFetch);

--- a/src/shared/api/api.instance.ts
+++ b/src/shared/api/api.instance.ts
@@ -135,7 +135,7 @@ class Api {
     const url = toQueryParams(path, options?.params);
 
     const response = await this.fetchFn(url, {
-      method: "POST",
+      method: "DELETE",
       ...restFetchOptions,
       headers: {
         ...restFetchOptions.headers,

--- a/src/shared/api/app-fetch.ts
+++ b/src/shared/api/app-fetch.ts
@@ -1,9 +1,7 @@
 import { getIsClient } from "../lib/get-is-client";
 import { clientAppFetch } from "./client-app-fetch";
 
-export async function appFetch(
-  ...args: Parameters<typeof fetch>
-): Promise<ReturnType<typeof fetch>> {
+export async function appFetch(...args: Parameters<typeof fetch>): Promise<Response> {
   const isClient = getIsClient();
 
   if (isClient) {

--- a/src/shared/lib/to-form-data.ts
+++ b/src/shared/lib/to-form-data.ts
@@ -1,0 +1,63 @@
+export type ToFormDataOptions = {
+  includeNull?: boolean;
+  includeUndefined?: boolean;
+};
+
+export function toFormData(data: Record<string, any>, options: ToFormDataOptions = {}) {
+  const form = new FormData();
+
+  Object.entries(data).forEach(([key, value]) => processValue(form, key, value, options));
+
+  return form;
+}
+
+function processValue(
+  form: FormData,
+  key: string,
+  value: any,
+  options: ToFormDataOptions = {}
+) {
+  value.forEach(() => {
+    if (value === null && options.includeNull) {
+      form.append(key, value);
+
+      return;
+    }
+
+    if (value === undefined && options.includeUndefined) {
+      form.append(key, value);
+
+      return;
+    }
+
+    if (typeof value === "string") {
+      form.append(key, value);
+
+      return;
+    }
+
+    if (typeof value === "number") {
+      form.append(key, String(value));
+
+      return;
+    }
+
+    if (value instanceof File) {
+      form.append(key, value, value.name);
+
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((val, index) => processValue(form, `${key}[${index}]`, val));
+
+      return;
+    }
+
+    if (typeof value === "object") {
+      Object.entries(value).forEach(([nestedKey, nestedValue]) =>
+        processValue(form, `${key}[${nestedKey}]`, nestedValue)
+      );
+    }
+  });
+}


### PR DESCRIPTION
# Api instance based on fetch

## Cause

Most of our workers used to axios. But axios uses old xhr request which is unnecessary in 99.99% of projects (except cases when we need to get images/videos streams)

Nextjs extends fetch API to allow us pass additional parameters that opts in caching and revalidation. E.g. properties: revalidate, tags, cache.  [Read more](https://nextjs.org/docs/app/api-reference/functions/fetch)

## Proposal
I suggest to create our own api instance with similar API to axios but based on fetch.

## Proses: 

- We have ability to access nextjs fetch API
- We have more control over fetching code so it is easier to understand how code works without need to reading sources
- We have convenient API which we can discuss and adjust with team
- Weights much less than axios so we reduce bundle for all our projects

## Cons:
- We need to maintain this solution by ourselvs
- We need to write tests

## Need to be done after proposal acceptance

- [ ] Create types folde for api instace and move all types of api to it 
- [ ] Write tests
- [ ] Write documentation
- [ ] Use in all examples